### PR TITLE
refactor: CountryController, DiaryController를 JWT 인증 방식으로 변경

### DIFF
--- a/src/main/java/zim/tave/memory/controller/CountryController.java
+++ b/src/main/java/zim/tave/memory/controller/CountryController.java
@@ -2,6 +2,7 @@ package zim.tave.memory.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import zim.tave.memory.service.VisitedCountryService;
 import zim.tave.memory.service.CountryService;
@@ -18,6 +19,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import zim.tave.memory.domain.Country;
 import zim.tave.memory.dto.CountrySearchResponseDto;
 import zim.tave.memory.dto.ListResponse;
+import zim.tave.memory.security.CustomUserDetails;
 
 import java.util.List;
 
@@ -30,16 +32,17 @@ public class CountryController {
     private final VisitedCountryService visitedCountryService;
     private final CountryService countryService;
 
-    @Operation(summary = "특정 사용자의 방문 국가 전체 조회", description = "userId로 방문 국가와 감정 정보를 조회합니다.")
+    @Operation(summary = "사용자의 방문 국가 전체 조회", description = "JWT 토큰으로 인증된 사용자의 방문 국가와 감정 정보를 조회합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "조회 성공",
             content = @Content(schema = @Schema(implementation = VisitedCountryResponseDto.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content()),
         @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content())
     })
-    @GetMapping("/{userId}")
+    @GetMapping("/my-countries")
     public ResponseEntity<ListResponse<VisitedCountryResponseDto>> getVisitedCountries(
-        @Parameter(description = "조회할 사용자 ID", example = "1")
-        @PathVariable Long userId) {
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
         List<VisitedCountryResponseDto> visitedCountries = visitedCountryService.getVisitedCountries(userId)
                 .stream()
                 .map(VisitedCountryResponseDto::from)
@@ -48,6 +51,7 @@ public class CountryController {
     }
 
 
+    // 공통 마스터 데이터 조회이므로 JWT 인증 불필요 - 모든 사용자가 동일한 국가 목록 검색
     @Operation(summary = "나라 검색", description = "한글로 나라 이름을 검색합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "검색 성공",
@@ -58,6 +62,7 @@ public class CountryController {
     public ResponseEntity<ListResponse<CountrySearchResponseDto>> searchCountries(
         @Parameter(description = "검색할 나라 이름(한글)", example = "한국")
         @RequestParam String keyword
+        
     ) {
         try {
             // Controller에서 빈 키워드일 때 빈 리스트 반환하지 않고, service에서 전체 국가 반환하도록 위임
@@ -76,15 +81,16 @@ public class CountryController {
 
     
 
-    @Operation(summary = "방문 국가 저장", description = "국가코드와 감정ID로 방문 국가를 저장합니다.")
+    @Operation(summary = "방문 국가 저장", description = "JWT 토큰으로 인증된 사용자의 방문 국가를 저장합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "저장 성공", content = @Content()),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content()),
+        @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content()),
         @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content())
     })
-    @PostMapping("/{userId}")
+    @PostMapping("/register")
     public ResponseEntity<Void> registerVisitedCountry(
-        @Parameter(description = "사용자 ID", example = "1")
-        @PathVariable Long userId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
         @io.swagger.v3.oas.annotations.parameters.RequestBody(
             description = "방문 국가 등록 요청 DTO (countryCode, emotionId)",
             required = true,
@@ -93,6 +99,7 @@ public class CountryController {
         @RequestBody RegisterVisitedCountryRequestDto requestDto
     ) {
         try {
+            Long userId = userDetails.getUserId();
             visitedCountryService.registerVisitedCountry(userId, requestDto.getCountryCode(), requestDto.getEmotionId());
             return ResponseEntity.ok().build();
         } catch (IllegalArgumentException e) {
@@ -113,31 +120,32 @@ public class CountryController {
         }
     }
 
-    @Operation(summary = "특정 방문 국가 삭제", description = "userId와 countryCode로 방문 국가를 삭제합니다.")
+    @Operation(summary = "방문 국가 삭제", description = "JWT 토큰으로 인증된 사용자의 방문 국가를 삭제합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "삭제 성공", content = @Content()),
+        @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content()),
         @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content())
     })
-    @DeleteMapping("/{userId}")
+    @DeleteMapping("/delete")
     public ResponseEntity<Void> deleteVisitedCountry(
-        @Parameter(description = "사용자 ID", example = "1")
-        @PathVariable Long userId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
         @Parameter(description = "삭제할 국가 코드", example = "KR")
         @RequestParam String countryCode
     ) {
+        Long userId = userDetails.getUserId();
         visitedCountryService.deleteVisitedCountry(userId, countryCode);
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "특정 국가 감정 색상 수정", description = "userId와 countryCode로 방문 국가의 감정 색상을 수정합니다.")
+    @Operation(summary = "방문 국가 감정 색상 수정", description = "JWT 토큰으로 인증된 사용자의 방문 국가 감정 색상을 수정합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content()),
+        @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content()),
         @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content())
     })
-    @PatchMapping("/{userId}/color")
+    @PatchMapping("/color")
     public ResponseEntity<Void> updateVisitedCountryColor(
-        @Parameter(description = "사용자 ID", example = "1")
-        @PathVariable Long userId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
         @io.swagger.v3.oas.annotations.parameters.RequestBody(
             description = "방문 국가 색상 수정 요청 DTO (countryCode, newColor)",
             required = true,
@@ -145,6 +153,7 @@ public class CountryController {
         )
         @RequestBody UpdateVisitedCountryColorRequestDto requestDto
     ) {
+        Long userId = userDetails.getUserId();
         visitedCountryService.updateVisitedCountryColor(userId, requestDto.getCountryCode(), requestDto.getNewColor());
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/zim/tave/memory/controller/DiaryController.java
+++ b/src/main/java/zim/tave/memory/controller/DiaryController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import zim.tave.memory.domain.Diary;
 import zim.tave.memory.domain.DiaryImage;
@@ -17,6 +18,7 @@ import zim.tave.memory.dto.CreateDiaryRequest;
 import zim.tave.memory.dto.DiaryResponseDto;
 import zim.tave.memory.dto.UpdateDiaryOptionalFieldsRequest;
 import zim.tave.memory.dto.UpdateRepresentativeImageRequest;
+import zim.tave.memory.security.CustomUserDetails;
 import zim.tave.memory.service.DiaryService;
 
 import java.util.List;
@@ -31,14 +33,19 @@ public class DiaryController {
     private final DiaryService diaryService;
 
     @PostMapping
-    @Operation(summary = "일기 생성", description = "새로운 일기를 생성합니다. 정면/후면 카메라 사진 각 1장씩, 총 2장의 이미지가 필요하며 그 중 1장을 대표 이미지로 설정해야 합니다.")
+    @Operation(summary = "일기 생성", description = "JWT 토큰으로 인증된 사용자의 일기를 생성합니다. 정면/후면 카메라 사진 각 1장씩, 총 2장의 이미지가 필요하며 그 중 1장을 대표 이미지로 설정해야 합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "일기 생성 성공",
                     content = @Content(schema = @Schema(implementation = DiaryResponseDto.class))),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터 (필수 필드 누락, 이미지 개수 오류, 카메라 타입 누락 등)", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content()),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
-    public ResponseEntity<DiaryResponseDto> createDiary(@RequestBody CreateDiaryRequest request) {
+    public ResponseEntity<DiaryResponseDto> createDiary(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody CreateDiaryRequest request) {
+        Long userId = userDetails.getUserId();
+        request.setUserId(userId); // JWT에서 추출한 userId를 request에 설정
         System.out.println("=== 일기 생성 요청 시작 ===");
         System.out.println("Request: " + request);
         
@@ -120,87 +127,74 @@ public class DiaryController {
         }
     }
 
+    // 일기 선택 필드 수정 - JWT 인증으로 본인 일기만 수정 가능
     @PutMapping("/{diaryId}/optional-fields")
-    @Operation(summary = "일기 선택 필드 수정", description = "일기의 선택적 필드들(감정, 날씨 등)을 수정합니다.")
+    @Operation(summary = "일기 선택 필드 수정", description = "JWT 토큰으로 인증된 사용자의 일기 선택적 필드들(감정, 날씨 등)을 수정합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "일기 수정 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content()),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (다른 사용자의 일기)", content = @Content()),
             @ApiResponse(responseCode = "404", description = "일기를 찾을 수 없음", content = @Content)
     })
     public ResponseEntity<Void> updateDiaryOptionalFields(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "일기 ID", required = true) @PathVariable Long diaryId,
             @RequestBody UpdateDiaryOptionalFieldsRequest request) {
+        Long userId = userDetails.getUserId();
+        Diary diary = diaryService.findOne(diaryId);
+        
+        // 본인의 일기인지 확인
+        if (!diary.getUser().getId().equals(userId)) {
+            System.out.println("권한 없음: 사용자 " + userId + "가 다른 사용자의 일기 " + diaryId + " 수정 시도");
+            return ResponseEntity.status(403).build();
+        }
+        
         diaryService.updateDiaryOptionalFields(diaryId, request);
         return ResponseEntity.ok().build();
     }
 
+    // 대표 이미지 변경 - JWT 인증으로 본인 일기만 수정 가능
     @PutMapping("/{diaryId}/representative-image")
-    @Operation(summary = "대표 이미지 변경", description = "일기의 대표 이미지를 변경합니다.")
+    @Operation(summary = "대표 이미지 변경", description = "JWT 토큰으로 인증된 사용자의 일기 대표 이미지를 변경합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "대표 이미지 변경 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content()),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (다른 사용자의 일기)", content = @Content()),
             @ApiResponse(responseCode = "404", description = "일기 또는 이미지를 찾을 수 없음", content = @Content)
     })
     public ResponseEntity<Void> updateRepresentativeImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "일기 ID", required = true) @PathVariable Long diaryId,
             @RequestBody UpdateRepresentativeImageRequest request) {
         if (request.getImageId() == null) {
             return ResponseEntity.badRequest().build();
         }
         
+        Long userId = userDetails.getUserId();
+        Diary diary = diaryService.findOne(diaryId);
+        
+        // 본인의 일기인지 확인
+        if (!diary.getUser().getId().equals(userId)) {
+            System.out.println("권한 없음: 사용자 " + userId + "가 다른 사용자의 일기 " + diaryId + " 이미지 변경 시도");
+            return ResponseEntity.status(403).build();
+        }
+        
         diaryService.updateRepresentativeImage(diaryId, request.getImageId());
         return ResponseEntity.ok().build();
     }
 
+    // 사용자별 전체 일기 목록 조회 - JWT 인증으로 개인 데이터 보호
     @GetMapping
-    @Operation(summary = "전체 일기 목록 조회", description = "모든 일기의 목록을 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "일기 목록 조회 성공",
-            content = @Content(schema = @Schema(implementation = DiaryResponseDto.class)))
-    public ResponseEntity<List<DiaryResponseDto>> getAllDiaries() {
-        List<Diary> diaries = diaryService.findAll();
-        List<DiaryResponseDto> diaryDtos = diaries.stream()
-                .map(DiaryResponseDto::from)
-                .collect(Collectors.toList());
-        return ResponseEntity.ok(diaryDtos);
-    }
-
-    @GetMapping("/{diaryId}")
-    @Operation(summary = "일기 상세 조회", description = "특정 일기의 상세 정보를 조회합니다.")
+    @Operation(summary = "내 전체 일기 목록 조회", description = "JWT 토큰으로 인증된 사용자의 모든 일기를 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "일기 조회 성공",
+            @ApiResponse(responseCode = "200", description = "일기 목록 조회 성공",
                     content = @Content(schema = @Schema(implementation = DiaryResponseDto.class))),
-            @ApiResponse(responseCode = "404", description = "일기를 찾을 수 없음", content = @Content)
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content())
     })
-    public ResponseEntity<DiaryResponseDto> getDiary(
-            @Parameter(description = "일기 ID", required = true) @PathVariable Long diaryId) {
-        Diary diary = diaryService.findOne(diaryId);
-        return ResponseEntity.ok(DiaryResponseDto.from(diary));
-    }
-
-    @GetMapping("/trip/{tripId}")
-    @Operation(summary = "여행별 일기 목록 조회", description = "특정 여행에 속한 모든 일기를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "여행 일기 목록 조회 성공",
-                    content = @Content(schema = @Schema(implementation = DiaryResponseDto.class))),
-            @ApiResponse(responseCode = "404", description = "여행을 찾을 수 없음", content = @Content)
-    })
-    public ResponseEntity<List<DiaryResponseDto>> getDiariesByTripId(
-            @Parameter(description = "여행 ID", required = true) @PathVariable Long tripId) {
-        List<Diary> diaries = diaryService.findByTripId(tripId);
-        List<DiaryResponseDto> diaryDtos = diaries.stream()
-                .map(DiaryResponseDto::from)
-                .collect(Collectors.toList());
-        return ResponseEntity.ok(diaryDtos);
-    }
-
-    @GetMapping("/user/{userId}")
-    @Operation(summary = "사용자별 일기 목록 조회", description = "특정 사용자의 모든 일기를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "사용자 일기 목록 조회 성공",
-                    content = @Content(schema = @Schema(implementation = DiaryResponseDto.class))),
-            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content)
-    })
-    public ResponseEntity<List<DiaryResponseDto>> getDiariesByUserId(
-            @Parameter(description = "사용자 ID", required = true) @PathVariable Long userId) {
+    public ResponseEntity<List<DiaryResponseDto>> getMyAllDiaries(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
         List<Diary> diaries = diaryService.findByUserId(userId);
         List<DiaryResponseDto> diaryDtos = diaries.stream()
                 .map(DiaryResponseDto::from)
@@ -208,14 +202,80 @@ public class DiaryController {
         return ResponseEntity.ok(diaryDtos);
     }
 
+    // 특정 일기 상세 조회 - JWT 인증으로 본인 일기만 조회 가능하도록 보안 강화
+    @GetMapping("/{diaryId}")
+    @Operation(summary = "일기 상세 조회", description = "JWT 토큰으로 인증된 사용자의 특정 일기를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일기 조회 성공",
+                    content = @Content(schema = @Schema(implementation = DiaryResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content()),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (다른 사용자의 일기)", content = @Content()),
+            @ApiResponse(responseCode = "404", description = "일기를 찾을 수 없음", content = @Content)
+    })
+    public ResponseEntity<DiaryResponseDto> getDiary(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "일기 ID", required = true) @PathVariable Long diaryId) {
+        Long userId = userDetails.getUserId();
+        Diary diary = diaryService.findOne(diaryId);
+        
+        // 본인의 일기인지 확인
+        if (!diary.getUser().getId().equals(userId)) {
+            System.out.println("권한 없음: 사용자 " + userId + "가 다른 사용자의 일기 " + diaryId + " 접근 시도");
+            return ResponseEntity.status(403).build();
+        }
+        
+        return ResponseEntity.ok(DiaryResponseDto.from(diary));
+    }
+
+    // 내 여행별 일기 목록 조회 - JWT 인증으로 본인 여행의 일기만 조회
+    @GetMapping("/trip/{tripId}")
+    @Operation(summary = "내 여행별 일기 목록 조회", description = "JWT 토큰으로 인증된 사용자의 특정 여행에 속한 모든 일기를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "여행 일기 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = DiaryResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content()),
+            @ApiResponse(responseCode = "404", description = "여행을 찾을 수 없음", content = @Content)
+    })
+    public ResponseEntity<List<DiaryResponseDto>> getMyDiariesByTripId(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "여행 ID", required = true) @PathVariable Long tripId) {
+        Long userId = userDetails.getUserId();
+        List<Diary> diaries = diaryService.findByTripId(tripId);
+        
+        // 본인의 여행인지 확인 (첫 번째 일기의 사용자 확인)
+        if (!diaries.isEmpty() && !diaries.get(0).getUser().getId().equals(userId)) {
+            System.out.println("권한 없음: 사용자 " + userId + "가 다른 사용자의 여행 " + tripId + " 일기 접근 시도");
+            return ResponseEntity.status(403).build();
+        }
+        
+        List<DiaryResponseDto> diaryDtos = diaries.stream()
+                .map(DiaryResponseDto::from)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(diaryDtos);
+    }
+
+
+    // 일기 삭제 - JWT 인증으로 본인 일기만 삭제 가능
     @DeleteMapping("/{diaryId}")
-    @Operation(summary = "일기 삭제", description = "특정 일기를 삭제합니다.")
+    @Operation(summary = "일기 삭제", description = "JWT 토큰으로 인증된 사용자의 특정 일기를 삭제합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "일기 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content()),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (다른 사용자의 일기)", content = @Content()),
             @ApiResponse(responseCode = "404", description = "일기를 찾을 수 없음", content = @Content)
     })
     public ResponseEntity<Void> deleteDiary(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "일기 ID", required = true) @PathVariable Long diaryId) {
+        Long userId = userDetails.getUserId();
+        Diary diary = diaryService.findOne(diaryId);
+        
+        // 본인의 일기인지 확인
+        if (!diary.getUser().getId().equals(userId)) {
+            System.out.println("권한 없음: 사용자 " + userId + "가 다른 사용자의 일기 " + diaryId + " 삭제 시도");
+            return ResponseEntity.status(403).build();
+        }
+        
         diaryService.deleteDiary(diaryId);
         return ResponseEntity.ok().build();
     }


### PR DESCRIPTION
# CountryController JWT 인증 방식 전환
##  주요 변경사항

### 1. 인증 방식 전환
**기존 (PathVariable 방식)**
```java
@GetMapping("/{userId}")
public ResponseEntity getVisitedCountries(@PathVariable Long userId) {
    // userId를 URL에서 직접 받음
}
```

**변경 (JWT 인증 방식)**
```java
@GetMapping("/my-countries")
public ResponseEntity getVisitedCountries(@AuthenticationPrincipal CustomUserDetails userDetails) {
    Long userId = userDetails.getUserId(); // JWT 토큰에서 추출
}
```

### 2. API 엔드포인트 변경

| 기능 | 기존 엔드포인트 | 변경 엔드포인트 |
|-----|---------------|---------------|
| 방문 국가 조회 | `GET /api/countries/{userId}` | `GET /api/countries/my-countries` |
| 방문 국가 등록 | `POST /api/countries/{userId}` | `POST /api/countries/register` |
| 방문 국가 삭제 | `DELETE /api/countries/{userId}` | `DELETE /api/countries/delete` |
| 감정 색상 수정 | `PATCH /api/countries/{userId}/color` | `PATCH /api/countries/color` |

### 3. 공통 API 유지
- `GET /api/countries/search` - JWT 인증 불필요
- 이유: 공통 마스터 데이터 조회로 모든 사용자가 동일한 국가 목록 검색
- 성능 최적화: 캐싱 효과 극대화 및 서버 부하 감소

# DiaryController JWT 인증 추가

#### 1. **모든 일기 API에 JWT 인증 적용**
- **보안 강화**: 모든 API에서 사용자 인증 필수
- **권한 검증**: 본인의 일기만 조회/수정/삭제 가능하도록 403 Forbidden 응답 추가" 

#### 2. 변경된 API
| API | 기존 방식 | 변경 방식 | 보안 기능 |
|-----|----------|----------|----------|
| 전체 일기 조회 | `GET /api/diaries` (모든 사용자 일기) | `GET /api/diaries` (내 일기만) | ✅ JWT 인증 |
| 일기 상세 조회 | `GET /api/diaries/{diaryId}` | `GET /api/diaries/{diaryId}` | ✅ JWT + 소유권 검증 |
| 여행별 일기 | `GET /api/diaries/trip/{tripId}` | `GET /api/diaries/trip/{tripId}` | ✅ JWT + 소유권 검증 |
| 사용자별 일기 | `GET /api/diaries/user/{userId}` | **제거** (전체 조회로 통합) | - |
| 일기 생성 | `POST /api/diaries` (userId in body) | `POST /api/diaries` (JWT) | ✅ JWT 인증 |
| 일기 수정 | `PUT /api/diaries/{diaryId}/optional-fields` | `PUT /api/diaries/{diaryId}/optional-fields` | ✅ JWT + 소유권 검증 |
| 이미지 변경 | `PUT /api/diaries/{diaryId}/representative-image` | `PUT /api/diaries/{diaryId}/representative-image` | ✅ JWT + 소유권 검증 |
| 일기 삭제 | `DELETE /api/diaries/{diaryId}` | `DELETE /api/diaries/{diaryId}` | ✅ JWT + 소유권 검증 |

#### 3. 소유권 검증 로직 추가
모든 수정/삭제 API에 본인 확인 로직 추가:

#### 4. 응답 코드 추가
401 Unauthorized: JWT 토큰 없음 또는 유효하지 않음
403 Forbidden: 다른 사용자의 일기 접근 시도
404 Not Found: 일기를 찾을 수 없음
